### PR TITLE
Fixing benchmarking data overwrite

### DIFF
--- a/run-benchmarking-cpu.sh
+++ b/run-benchmarking-cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 currentDate=`date +%F`
-outputDir=tomopy.github.io/$currentDate
+outputDir=tomopy.github.io/$currentDate/cpu
 
 python -Om benchmarking.project \
   --poisson 5 \

--- a/run-benchmarking-gpu.sh
+++ b/run-benchmarking-gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 currentDate=`date +%F`
-outputDir=tomopy.github.io/$currentDate
+outputDir=tomopy.github.io/$currentDate/gpu
 
 python -Om benchmarking.project \
   --poisson 5 \


### PR DESCRIPTION
Changes benchmarking process so that the results of CPU and GPU tests are separated and do no overwrite each other. Closes #8. 