### PR TITLE
Forced scheduled tasks to run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ schedules:
     branches:
       include:
         - master
+    always: true
 
 trigger:
 - master


### PR DESCRIPTION
The Azure pipelines will not run schedule processes if there have been no code changes since the last pipeline process ran. This pull request will force the pipelines to run even if there have been no code changes.