### PR TITLE
Separate pipeline summary from projection and reconstruction

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -311,6 +311,7 @@ jobs:
               --output-dir $outputDir
 
         cd tomopy.github.io
+        find . -name "*.npz" -delete
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
         git add *

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,222 +14,179 @@ schedules:
 trigger:
 - master
 
-jobs:
+stages:
 
-- job: CPU_Benchmarks
-  timeoutInMinutes: 0
+- stage: Run_benchmarks
+
+  jobs:
+
+  - job: CPU_Benchmarks
+    timeoutInMinutes: 0
+    dependsOn: Compute_projection
+
+    pool:
+      name: Default
+      demands: 
+        - Agent.OS -equals Linux
+
+    strategy:
+      matrix:
+        GRIDREC:
+          algorithmName: 'gridrec'
+  #       ART:
+  #         algorithmName: 'art'
+  #       BART:
+  #         algorithmName: 'bart'
+  #       MLEM:
+  #         algorithmName: 'mlem'
+  #       OSEM: 
+  #         algorithmName: 'osem'
+  #       OSPML_Hybrid:
+  #         algorithmName: 'ospml_hybrid'
+  #       OSPML_Quad: 
+  #         algorithmName: 'ospml_quad'
+  #       PML_Hybrid: 
+  #         algorithmName: 'pml_hybrid'
+  #       PML_Quad: 
+  #         algorithmName: 'pml_quad'
+  #       SIRT:
+  #         algorithmName: 'sirt'
+  #       TV:
+  #         algorithmName: 'tv'
+
+    steps:
+
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: Add conda to PATH
+
+    - download: current
+      artifact: local
+
+    - script: |
+        conda env remove --yes -n tomopy-bench
+        rm -rf tomopy.github.io
+      displayName: Remove existing build environment  
+      
+    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+      displayName: 'Create benchmarking environment'
+
+    - script: conda list -n tomopy-bench
+      displayName: 'List conda environment'
+
+    - script: |
+        source activate tomopy-bench
+        git clone https://github.com/tomopy/tomopy
+        cd tomopy
+        python setup.py install
+      displayName: Install TomoPy
+
+    - script: |
+        source activate tomopy-bench
+    
+        python -Om benchmarking.reconstruct \
+          --ncore 4 \
+          --max-iter 50 \
+          --output-dir local \
+          --algorithm $(algorithmName)
+      displayName: 'Run benchmarks'
+
+    - publish: local
+      artifact: local
+
+  - job: GPU_Benchmarks
+    timeoutInMinutes: 0
+    dependsOn: Compute_projection
+
+    pool:
+      name: Default
+      demands:
+        - CUDA_VERSION
+        - Agent.OS -equals Linux
+
+    strategy:
+      matrix:
+        SIRT_GPU:
+          algorithmName: 'sirt_gpu'
+        # MLEM_GPU:
+        #   algorithmName: 'mlem_gpu'
+
+    steps: 
+
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: Add conda to PATH
+
+    - download: current
+      artifact: local
+
+    - script: |
+          conda env remove --yes -n tomopy-bench
+          rm -rf tomopy.github.io
+      displayName: Remove existing build environment
+
+    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+      displayName: 'Create benchmarking environment'
+
+    - script: conda list -n tomopy-bench
+      displayName: 'List conda environment'
+
+    - script: |
+        source activate tomopy-bench
+        git clone https://github.com/tomopy/tomopy
+        cd tomopy
+        python setup.py install --enable-cuda --cuda-arch=30
+      displayName: Install TomoPy
+
+    - script: |
+        source activate tomopy-bench
+
+        python -Om benchmarking.reconstruct \
+          --ncore 4 \
+          --max-iter 50 \
+          --algorithm $(algorithmName)
+          --output-dir local
+      displayName: 'Run benchmarks'
+
+    - publish: local
+      artifact: local
+
+    # - script: |
+    #     conda env remove --yes -n tomopy-bench
+    #     rm -rf tomopy.github.io
+    #     rm -rf tomopy
+    #   displayName: Remove existing build environment
+  
+- stage: Summarize_results
 
   pool:
     name: Default
     demands: 
       - Agent.OS -equals Linux
 
-  strategy:
-    matrix:
-      GRIDREC:
-        algorithmName: 'gridrec'
-#       ART:
-#         algorithmName: 'art'
-#       BART:
-#         algorithmName: 'bart'
-#       MLEM:
-#         algorithmName: 'mlem'
-#       OSEM: 
-#         algorithmName: 'osem'
-#       OSPML_Hybrid:
-#         algorithmName: 'ospml_hybrid'
-#       OSPML_Quad: 
-#         algorithmName: 'ospml_quad'
-#       PML_Hybrid: 
-#         algorithmName: 'pml_hybrid'
-#       PML_Quad: 
-#         algorithmName: 'pml_quad'
-#       SIRT:
-#         algorithmName: 'sirt'
-#       TV:
-#         algorithmName: 'tv'
-
   steps:
 
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - download: current
+    artifact: gridrec
+
+  - download: current
+    artifact: sirt_gpu
+
+  - bash: ls
+    displayName: list directories
 
   - script: |
-      conda env remove --yes -n tomopy-bench
-      rm -rf tomopy.github.io
-    displayName: Remove existing build environment  
-  - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
-    displayName: 'Create benchmarking environment'
-
-  - script: conda list -n tomopy-bench
-    displayName: 'List conda environment'
-
-  - script: |
-      source activate tomopy-bench
-      git clone https://github.com/tomopy/tomopy
-      cd tomopy
-      python setup.py install
-    displayName: Install TomoPy
-  - script: |
-      source activate tomopy-bench
-      cd tomopy
-      pytest
-    displayName: Test TomoPy installation
-    
-  - script: git clone https://github.com/tomopy/tomopy.github.io
-    displayName: 'Clone tomopy benchmarks repo'
-
-  - script: |
-      cd tomopy.github.io
-      source activate tomopy-bench
-      TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-      BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
-      git checkout -B $BRANCH_NAME
-      
-      cd ..
       currentDate=`date +%F`
-      outputDir=tomopy.github.io/$currentDate/cpu
-
-      python -Om benchmarking.project \
-        --poisson 500 \
-        --trials 4 \
-        --width 1446 \
-        --num-angles 1500 \
-        --phantom peppers \
-        --output-dir $outputDir \
-
-      python -Om benchmarking.reconstruct \
-        --ncore 4 \
-        --max-iter 50 \
-        --phantom peppers \
-        --output-dir $outputDir \
-        --algorithm $(algorithmName)
+      outputDir=tomopy.github.io/$currentDate
 
       python -Om benchmarking.summarize \
-        --phantom peppers \
-        --trials 4 \
-        --output-dir $outputDir \
-    displayName: 'Run benchmarks'
+            --phantom peppers \
+            --trials 4 \
+            --output-dir $outputDir \
+
+    displayName: Compile data
 
   - script: |
-      cd tomopy.github.io
-      source activate tomopy-bench
-      TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-      BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
-      git checkout $BRANCH_NAME
-      
-      git config --global user.name "Dreycen Foiles"
-      git config --global user.email "foilesdreycen@gmail.com"
-      git add *
-      git commit -m "Bi-monthly benchmark"
-      git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io $BRANCH_NAME
-    displayName: 'Update benchmarking data repository'
-
-  - script: |
-      conda env remove --yes -n tomopy-bench
-      rm -rf tomopy.github.io
-      rm -rf tomopy
-    displayName: Remove existing build environment
-
-- job: GPU_Benchmarks
-
-  timeoutInMinutes: 0
-
-  pool:
-    name: Default
-    demands:
-      - CUDA_VERSION
-      - Agent.OS -equals Linux
-
-  strategy:
-    matrix:
-      SIRT_GPU:
-        algorithmName: 'sirt_gpu'
-      # MLEM_GPU:
-      #   algorithmName: 'mlem_gpu'
-
-  steps: 
-
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
-
-  - script: |
-        conda env remove --yes -n tomopy-bench
-        rm -rf tomopy.github.io
-    displayName: Remove existing build environment
-
-  - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
-    displayName: 'Create benchmarking environment'
-
-  - script: conda list -n tomopy-bench
-    displayName: 'List conda environment'
-
-  - script: |
-      source activate tomopy-bench
-      git clone https://github.com/tomopy/tomopy
-      cd tomopy
-      python setup.py install --enable-cuda --cuda-arch=30
-    displayName: Install TomoPy
-
-  - script: |
-      source activate tomopy-bench
-      cd tomopy
-      pytest
-    displayName: Test TomoPy installation
-
-  - script: |
-      git clone https://github.com/tomopy/tomopy.github.io
-    displayName: 'Clone tomopy benchmarks repo'
-
-  - script: |
-      cd tomopy.github.io
-      source activate tomopy-bench
-      TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-      BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
-      git checkout -B $BRANCH_NAME
-      
-      cd ..
-      currentDate=`date +%F`
-      outputDir=tomopy.github.io/$currentDate/gpu
-
-      python -Om benchmarking.project \
-        --poisson 500 \
-        --trials 4 \
-        --width 1446 \
-        --num-angles 1500 \
-        --phantom peppers \
-        --output-dir $outputDir \
-
-      python -Om benchmarking.reconstruct \
-        --ncore 4 \
-        --max-iter 50 \
-        --phantom peppers \
-        --output-dir $outputDir \
-        --algorithm $(algorithmName)
-
-      python -Om benchmarking.summarize \
-        --phantom peppers \
-        --trials 4 \
-        --output-dir $outputDir \
-    displayName: 'Run benchmarks'
-
-  - script: |
-      cd tomopy.github.io
-      source activate tomopy-bench
-      TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-      BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
-      git checkout $BRANCH_NAME
-      git config --global user.name "Dreycen Foiles"
-      git config --global user.email "foilesdreycen@gmail.com"
-      git add *
-      git commit -m "Bi-monthly benchmark"
-      git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io $BRANCH_NAME
-    displayName: 'Update benchmarking data repository'
-
-  - script: |
-      conda env remove --yes -n tomopy-bench
-      rm -rf tomopy.github.io
-      rm -rf tomopy
-    displayName: Remove existing build environment
-  
-
+        cd tomopy.github.io
+        source activate tomopy-bench
+        BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
+        git checkout $BRANCH_NAME
+        git config --global user.name "Dreycen Foiles"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,34 +27,34 @@ jobs:
 
     steps:
 
-      # - bash: echo "##vso[task.prependpath]$CONDA/bin"
-      #   displayName: Add conda to PATH
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
+        displayName: Add conda to PATH
 
-      # - script: |
-      #     conda env remove --yes -n tomopy-bench
-      #     rm -rf tomopy.github.io
-      #     rm -rf tomopy
-      #   displayName: Remove existing build environment
+      - script: |
+          conda env remove --yes -n tomopy-bench
+          rm -rf tomopy.github.io
+          rm -rf tomopy
+        displayName: Remove existing build environment
 
-      # - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
-      #   displayName: 'Create benchmarking environment'
+      - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
+        displayName: 'Create benchmarking environment'
 
-      # - script: |
-      #     source activate tomopy-bench
-      #     git clone --depth 10 https://github.com/tomopy/tomopy
-      #     cd tomopy
-      #     python setup.py install --enable-cuda --cuda-arch=30
-      #   displayName: Install TomoPy
+      - script: |
+          source activate tomopy-bench
+          git clone --depth 10 https://github.com/tomopy/tomopy
+          cd tomopy
+          python setup.py install --enable-cuda --cuda-arch=30
+        displayName: Install TomoPy
 
-      # - script: |
-      #     source activate tomopy-bench
-      #     cd tomopy
-      #     pip install pytest
-      #     pytest
-      #   displayName: Test TomoPy
+      - script: |
+          source activate tomopy-bench
+          cd tomopy
+          pip install pytest
+          pytest
+        displayName: Test TomoPy
 
-      # - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
-      #   displayName: Download benchmarking data repo
+      - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
+        displayName: Download benchmarking data repo
 
       - script: |
           source activate tomopy-bench
@@ -64,6 +64,7 @@ jobs:
           cd tomopy.github.io
           git checkout -B $BRANCH_NAME
           git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
+          git pull --no-rebase --allow-unrelated-histories -X theirs
           cd ..
 
           currentDate=`date +%F`
@@ -81,7 +82,7 @@ jobs:
           git config --global user.email "foilesdreycen@gmail.com"
           git add *
           git commit -m "Bi-monthly benchmark"
-          git pull --rebase --allow-unrelated-histories
+          git pull --no-rebase --allow-unrelated-histories -X ours
           git push https://$(PAT)@github.com/tomopy/tomopy.github.io
         displayName: Compute projections
 
@@ -159,6 +160,7 @@ jobs:
         cd tomopy.github.io
         git checkout -B $BRANCH_NAME
         git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
+        git pull --no-rebase --allow-unrelated-histories -X theirs
         cd ..
 
         currentDate=`date +%F`
@@ -175,7 +177,7 @@ jobs:
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
         git commit -m "Bi-monthly benchmark"
-        git pull --allow-unrelated-histories
+        git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
 
@@ -237,6 +239,7 @@ jobs:
         cd tomopy.github.io
         git checkout -B $BRANCH_NAME
         git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
+        git pull --no-rebase --allow-unrelated-histories -X theirs
         cd ..
 
         currentDate=`date +%F`
@@ -253,7 +256,7 @@ jobs:
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
         git commit -m "Bi-monthly benchmark"
-        git pull --allow-unrelated-histories
+        git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
 
@@ -276,9 +279,6 @@ jobs:
 
     steps:
 
-  - download: current
-    artifact: gridrec
-
     - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
       displayName: 'Create benchmarking environment'
 
@@ -286,10 +286,10 @@ jobs:
       displayName: Download repository
 
     - script: |
-          source activate tomopy-bench
-          git clone --depth 10 https://github.com/tomopy/tomopy
-          cd tomopy
-          python setup.py install
+        source activate tomopy-bench
+        git clone --depth 10 https://github.com/tomopy/tomopy
+        cd tomopy
+        python setup.py install
       displayName: Install TomoPy
 
     - script: |
@@ -300,9 +300,8 @@ jobs:
         cd tomopy.github.io
         git checkout -B $BRANCH_NAME
         git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
+        git pull --no-rebase --allow-unrelated-histories -X theirs
         cd ..
-
-    displayName: Compile data
 
         python -Om benchmarking.summarize \
               --phantom peppers \
@@ -314,7 +313,7 @@ jobs:
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
         git commit -m "Bi-monthly benchmark"
-        git pull --allow-unrelated-histories
+        git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Summarize data
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,9 +59,6 @@ stages:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
 
-    - download: current
-      artifact: local
-
     - script: |
         conda env remove --yes -n tomopy-bench
         rm -rf tomopy.github.io
@@ -75,23 +72,51 @@ stages:
 
     - script: |
         source activate tomopy-bench
-        git clone https://github.com/tomopy/tomopy
+        git clone --depth 1 https://github.com/tomopy/tomopy
         cd tomopy
         python setup.py install
       displayName: Install TomoPy
 
+    - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+      displayName: Download benchmarking data repo
+
     - script: |
         source activate tomopy-bench
-    
+        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+        BRANCH_NAME=$TOMOPY_VERSION
+
+        cd tomopy.github.io
+        git checkout -b $BRANCH_NAME
+        cd .. 
+
+        currentDate=`date +%F`
+        outputDir=tomopy.github.io/$currentDate/
+
         python -Om benchmarking.reconstruct \
           --ncore 4 \
           --max-iter 50 \
-          --output-dir local \
-          --algorithm $(algorithmName)
+          --output-dir $outputDir \
+          --algorithm $(algorithmName) \ 
       displayName: 'Run benchmarks'
 
-    - publish: local
-      artifact: local
+    - script: |
+        cd tomopy.github.io
+        source activate tomopy-bench
+        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+        BRANCH_NAME=$TOMOPY_VERSION
+        git checkout -b $BRANCH_NAME
+        git config --global user.name "Dreycen Foiles"
+        git config --global user.email "foilesdreycen@gmail.com"
+        git add *
+        git commit -m "Bi-monthly benchmark"
+        git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io
+      displayName: Add reconstruction algorithm to repository
+
+    - script: |
+        conda env remove --yes -n tomopy-bench
+        rm -rf tomopy.github.io
+        rm -rf tomopy
+      displayName: Remove existing build environment
 
   - job: GPU_Benchmarks
     timeoutInMinutes: 0
@@ -110,19 +135,16 @@ stages:
         # MLEM_GPU:
         #   algorithmName: 'mlem_gpu'
 
-    steps: 
+    steps:
 
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
 
-    - download: current
-      artifact: local
-
     - script: |
-          conda env remove --yes -n tomopy-bench
-          rm -rf tomopy.github.io
-      displayName: Remove existing build environment
-
+        conda env remove --yes -n tomopy-bench
+        rm -rf tomopy.github.io
+      displayName: Remove existing build environment  
+      
     - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
       displayName: 'Create benchmarking environment'
 
@@ -131,29 +153,51 @@ stages:
 
     - script: |
         source activate tomopy-bench
-        git clone https://github.com/tomopy/tomopy
+        git clone --depth 1 https://github.com/tomopy/tomopy
         cd tomopy
         python setup.py install --enable-cuda --cuda-arch=30
       displayName: Install TomoPy
 
+    - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+      displayName: Download benchmarking data repo
+
     - script: |
         source activate tomopy-bench
+        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+        BRANCH_NAME=$TOMOPY_VERSION
+
+        cd tomopy.github.io
+        git checkout -b $BRANCH_NAME
+        cd .. 
+
+        currentDate=`date +%F`
+        outputDir=tomopy.github.io/$currentDate/
 
         python -Om benchmarking.reconstruct \
           --ncore 4 \
           --max-iter 50 \
-          --algorithm $(algorithmName)
-          --output-dir local
+          --output-dir $outputDir \
+          --algorithm $(algorithmName) \ 
       displayName: 'Run benchmarks'
 
-    - publish: local
-      artifact: local
+    - script: |
+        cd tomopy.github.io
+        source activate tomopy-bench
+        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+        BRANCH_NAME=$TOMOPY_VERSION
+        git checkout -b $BRANCH_NAME
+        git config --global user.name "Dreycen Foiles"
+        git config --global user.email "foilesdreycen@gmail.com"
+        git add *
+        git commit -m "Bi-monthly benchmark"
+        git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io
+      displayName: Add reconstruction algorithm to repository
 
-    # - script: |
-    #     conda env remove --yes -n tomopy-bench
-    #     rm -rf tomopy.github.io
-    #     rm -rf tomopy
-    #   displayName: Remove existing build environment
+    - script: |
+        conda env remove --yes -n tomopy-bench
+        rm -rf tomopy.github.io
+        rm -rf tomopy
+      displayName: Remove existing build environment
   
 - stage: Summarize_results
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,43 +27,43 @@ jobs:
 
     steps:
 
-      - bash: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add conda to PATH
+      # - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      #   displayName: Add conda to PATH
 
-      - script: |
-          conda env remove --yes -n tomopy
-          rm -rf tomopy.github.io
-          rm -rf tomopy
-        displayName: Remove existing build environment
+      # - script: |
+      #     conda env remove --yes -n tomopy-bench
+      #     rm -rf tomopy.github.io
+      #     rm -rf tomopy
+      #   displayName: Remove existing build environment
 
-      - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
-        displayName: 'Create benchmarking environment'
+      # - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
+      #   displayName: 'Create benchmarking environment'
+
+      # - script: |
+      #     source activate tomopy-bench
+      #     git clone --depth 10 https://github.com/tomopy/tomopy
+      #     cd tomopy
+      #     python setup.py install --enable-cuda --cuda-arch=30
+      #   displayName: Install TomoPy
+
+      # - script: |
+      #     source activate tomopy-bench
+      #     cd tomopy
+      #     pip install pytest
+      #     pytest
+      #   displayName: Test TomoPy
+
+      # - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
+      #   displayName: Download benchmarking data repo
 
       - script: |
           source activate tomopy-bench
-          git clone --depth 10 https://github.com/tomopy/tomopy
-          cd tomopy
-          python setup.py install --enable-cuda --cuda-arch=30
-        displayName: Install TomoPy
-
-      - script: |
-          source activate tomopy-bench
-          cd tomopy
-          pip install pytest
-          pytest
-        displayName: Test TomoPy
-
-      - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
-        displayName: Download benchmarking data repo
-
-      - script: |
-          source activate tomopy-bench
-          pip install click
           TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
           BRANCH_NAME=$TOMOPY_VERSION
 
           cd tomopy.github.io
           git checkout -B $BRANCH_NAME
+          git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
           cd ..
 
           currentDate=`date +%F`
@@ -81,11 +81,12 @@ jobs:
           git config --global user.email "foilesdreycen@gmail.com"
           git add *
           git commit -m "Bi-monthly benchmark"
+          git pull --rebase --allow-unrelated-histories
           git push https://$(PAT)@github.com/tomopy/tomopy.github.io
         displayName: Compute projections
 
       - script: |
-          conda env remove --yes -n tomopy
+          conda env remove --yes -n tomopy-bench
           rm -rf tomopy.github.io
           rm -rf tomopy
         displayName: Remove existing build environment
@@ -147,7 +148,7 @@ jobs:
         python setup.py install
       displayName: Install TomoPy
 
-    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
       displayName: Download benchmarking data repo
 
     - script: |
@@ -156,7 +157,8 @@ jobs:
         BRANCH_NAME=$TOMOPY_VERSION
 
         cd tomopy.github.io
-        git checkout -b $BRANCH_NAME
+        git checkout -B $BRANCH_NAME
+        git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
         cd ..
 
         currentDate=`date +%F`
@@ -171,9 +173,9 @@ jobs:
         cd tomopy.github.io
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
-        git pull -f
         git add *
         git commit -m "Bi-monthly benchmark"
+        git pull --allow-unrelated-histories
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
 
@@ -224,7 +226,7 @@ jobs:
         python setup.py install --enable-cuda --cuda-arch=30
       displayName: Install TomoPy
 
-    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
       displayName: Download benchmarking data repo
 
     - script: |
@@ -233,7 +235,8 @@ jobs:
         BRANCH_NAME=$TOMOPY_VERSION
 
         cd tomopy.github.io
-        git checkout -b $BRANCH_NAME
+        git checkout -B $BRANCH_NAME
+        git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
         cd ..
 
         currentDate=`date +%F`
@@ -248,9 +251,9 @@ jobs:
         cd tomopy.github.io
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
-        git pull -f
         git add *
         git commit -m "Bi-monthly benchmark"
+        git pull --allow-unrelated-histories
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
 
@@ -279,7 +282,7 @@ jobs:
     - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
       displayName: 'Create benchmarking environment'
 
-    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io --no-single-branch
       displayName: Download repository
 
     - script: |
@@ -295,7 +298,8 @@ jobs:
         BRANCH_NAME=$TOMOPY_VERSION
 
         cd tomopy.github.io
-        git checkout -b $BRANCH_NAME
+        git checkout -B $BRANCH_NAME
+        git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
         cd ..
 
     displayName: Compile data
@@ -306,13 +310,11 @@ jobs:
               --output-dir $outputDir
 
         cd tomopy.github.io
-        source activate tomopy-bench
-        BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
-        git checkout $BRANCH_NAME
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
         git commit -m "Bi-monthly benchmark"
+        git pull --allow-unrelated-histories
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Summarize data
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
           git config --global user.name "Dreycen Foiles"
           git config --global user.email "foilesdreycen@gmail.com"
           git add *
-          git commit -m "Bi-monthly benchmark"
+          git commit -m "Simulate data for benchmark"
           git pull --no-rebase --allow-unrelated-histories -X ours
           git push https://$(PAT)@github.com/tomopy/tomopy.github.io
         displayName: Compute projections
@@ -176,7 +176,7 @@ jobs:
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
-        git commit -m "Bi-monthly benchmark"
+        git commit -m "Bi-monthly benchmark $(algorithmName)"
         git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
@@ -255,7 +255,7 @@ jobs:
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
-        git commit -m "Bi-monthly benchmark"
+        git commit -m "Bi-monthly benchmark $(algorithmName)"
         git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Compute reconstruction
@@ -315,7 +315,7 @@ jobs:
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
-        git commit -m "Bi-monthly benchmark"
+        git commit -m "Benchmark data summary"
         git pull --no-rebase --allow-unrelated-histories -X ours
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Summarize data

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       - script: |
           source activate tomopy-bench
           cd tomopy
-          pip install pytest
+          conda install pytest
           pytest
         displayName: Test TomoPy
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,6 @@ jobs:
       - script: |
           source activate tomopy-bench
           cd tomopy
-          conda install pytest
           pytest
         displayName: Test TomoPy
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,39 +21,39 @@ jobs:
 
     pool:
       name: Default
-      demands: 
+      demands:
         - CUDA_VERSION
         - Agent.OS -equals Linux
 
-    steps: 
+    steps:
 
       - bash: echo "##vso[task.prependpath]$CONDA/bin"
         displayName: Add conda to PATH
 
-      - script: |  
+      - script: |
           conda env remove --yes -n tomopy
           rm -rf tomopy.github.io
           rm -rf tomopy
         displayName: Remove existing build environment
 
-      - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+      - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
         displayName: 'Create benchmarking environment'
 
       - script: |
           source activate tomopy-bench
-          git clone --depth 1 https://github.com/tomopy/tomopy
+          git clone --depth 10 https://github.com/tomopy/tomopy
           cd tomopy
           python setup.py install --enable-cuda --cuda-arch=30
         displayName: Install TomoPy
-      
+
       - script: |
           source activate tomopy-bench
-          cd tomopy 
+          cd tomopy
           pip install pytest
-          pytest 
+          pytest
         displayName: Test TomoPy
 
-      - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+      - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
         displayName: Download benchmarking data repo
 
       - script: |
@@ -68,23 +68,23 @@ jobs:
 
           currentDate=`date +%F`
           outputDir=tomopy.github.io/$currentDate/
-    
+
           python -Om benchmarking.project \
             --poisson 500 \
             --trials 4 \
             --width 400 \
             --num-angles 50 \
-            --output-dir $outputDir 
+            --output-dir $outputDir
 
           cd tomopy.github.io
           git config --global user.name "Dreycen Foiles"
           git config --global user.email "foilesdreycen@gmail.com"
           git add *
           git commit -m "Bi-monthly benchmark"
-          git push https://$(PAT)@github.com/tomopy/tomopy.github.io 
+          git push https://$(PAT)@github.com/tomopy/tomopy.github.io
         displayName: Compute projections
 
-      - script: |  
+      - script: |
           conda env remove --yes -n tomopy
           rm -rf tomopy.github.io
           rm -rf tomopy
@@ -96,7 +96,7 @@ jobs:
 
     pool:
       name: Default
-      demands: 
+      demands:
         - Agent.OS -equals Linux
 
     strategy:
@@ -109,15 +109,15 @@ jobs:
   #         algorithmName: 'bart'
   #       MLEM:
   #         algorithmName: 'mlem'
-  #       OSEM: 
+  #       OSEM:
   #         algorithmName: 'osem'
   #       OSPML_Hybrid:
   #         algorithmName: 'ospml_hybrid'
-  #       OSPML_Quad: 
+  #       OSPML_Quad:
   #         algorithmName: 'ospml_quad'
-  #       PML_Hybrid: 
+  #       PML_Hybrid:
   #         algorithmName: 'pml_hybrid'
-  #       PML_Quad: 
+  #       PML_Quad:
   #         algorithmName: 'pml_quad'
   #       SIRT:
   #         algorithmName: 'sirt'
@@ -132,9 +132,9 @@ jobs:
     - script: |
         conda env remove --yes -n tomopy-bench
         rm -rf tomopy.github.io
-      displayName: Remove existing build environment  
-      
-    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+      displayName: Remove existing build environment
+
+    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
       displayName: 'Create benchmarking environment'
 
     - script: conda list -n tomopy-bench
@@ -142,12 +142,12 @@ jobs:
 
     - script: |
         source activate tomopy-bench
-        git clone --depth 1 https://github.com/tomopy/tomopy
+        git clone --depth 10 https://github.com/tomopy/tomopy
         cd tomopy
         python setup.py install
       displayName: Install TomoPy
 
-    - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
       displayName: Download benchmarking data repo
 
     - script: |
@@ -157,7 +157,7 @@ jobs:
 
         cd tomopy.github.io
         git checkout -b $BRANCH_NAME
-        cd .. 
+        cd ..
 
         currentDate=`date +%F`
         outputDir=tomopy.github.io/$currentDate/
@@ -166,12 +166,12 @@ jobs:
           --ncore 4 \
           --max-iter 50 \
           --output-dir $outputDir \
-          --algorithm $(algorithmName) 
+          --algorithm $(algorithmName)
 
         cd tomopy.github.io
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
-        git pull -f 
+        git pull -f
         git add *
         git commit -m "Bi-monthly benchmark"
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
@@ -209,9 +209,9 @@ jobs:
         conda env remove --yes -n tomopy-bench
         rm -rf tomopy.github.io
         rm -rf tomopy
-      displayName: Remove existing build environment  
-      
-    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+      displayName: Remove existing build environment
+
+    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
       displayName: 'Create benchmarking environment'
 
     - script: conda list -n tomopy-bench
@@ -219,12 +219,12 @@ jobs:
 
     - script: |
         source activate tomopy-bench
-        git clone --depth 1 https://github.com/tomopy/tomopy
+        git clone --depth 10 https://github.com/tomopy/tomopy
         cd tomopy
         python setup.py install --enable-cuda --cuda-arch=30
       displayName: Install TomoPy
 
-    - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
       displayName: Download benchmarking data repo
 
     - script: |
@@ -234,7 +234,7 @@ jobs:
 
         cd tomopy.github.io
         git checkout -b $BRANCH_NAME
-        cd .. 
+        cd ..
 
         currentDate=`date +%F`
         outputDir=tomopy.github.io/$currentDate/
@@ -243,12 +243,12 @@ jobs:
           --ncore 4 \
           --max-iter 50 \
           --output-dir $outputDir \
-          --algorithm $(algorithmName)  
+          --algorithm $(algorithmName)
 
         cd tomopy.github.io
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
-        git pull -f 
+        git pull -f
         git add *
         git commit -m "Bi-monthly benchmark"
         git push https://$(PAT)@github.com/tomopy/tomopy.github.io
@@ -259,12 +259,12 @@ jobs:
         rm -rf tomopy.github.io
         rm -rf tomopy
       displayName: Remove existing build environment
-  
+
   - job: Summarize_results
-      
+
     pool:
       name: Default
-      demands: 
+      demands:
         - Agent.OS -equals Linux
 
     dependsOn:
@@ -276,24 +276,35 @@ jobs:
   - download: current
     artifact: gridrec
 
-  - download: current
-    artifact: sirt_gpu
+    - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml
+      displayName: 'Create benchmarking environment'
 
-  - bash: ls
-    displayName: list directories
+    - bash: git clone --depth 10 https://github.com/tomopy/tomopy.github.io
+      displayName: Download repository
 
-  - script: |
-      currentDate=`date +%F`
-      outputDir=tomopy.github.io/$currentDate
+    - script: |
+          source activate tomopy-bench
+          git clone --depth 10 https://github.com/tomopy/tomopy
+          cd tomopy
+          python setup.py install
+      displayName: Install TomoPy
 
-      python -Om benchmarking.summarize \
-            --phantom peppers \
-            --trials 4 \
-            --output-dir $outputDir \
+    - script: |
+        source activate tomopy-bench
+        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+        BRANCH_NAME=$TOMOPY_VERSION
+
+        cd tomopy.github.io
+        git checkout -b $BRANCH_NAME
+        cd ..
 
     displayName: Compile data
 
-  - script: |
+        python -Om benchmarking.summarize \
+              --phantom peppers \
+              --trials 4 \
+              --output-dir $outputDir
+
         cd tomopy.github.io
         source activate tomopy-bench
         BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
@@ -302,7 +313,7 @@ jobs:
         git config --global user.email "foilesdreycen@gmail.com"
         git add *
         git commit -m "Bi-monthly benchmark"
-        git push https://$(PAT)@github.com/tomopy/tomopy.github.io 
+        git push https://$(PAT)@github.com/tomopy/tomopy.github.io
       displayName: Summarize data
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,81 @@ schedules:
 trigger:
 - master
 
-stages:
+jobs:
 
-- stage: Run_benchmarks
+  - job: Compute_projection
+    timeoutInMinutes: 0
 
-  jobs:
+    pool:
+      name: Default
+      demands: 
+        - CUDA_VERSION
+        - Agent.OS -equals Linux
+
+    steps: 
+
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
+        displayName: Add conda to PATH
+
+      - script: |  
+          conda env remove --yes -n tomopy
+          rm -rf tomopy.github.io
+          rm -rf tomopy
+        displayName: Remove existing build environment
+
+      - bash: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
+        displayName: 'Create benchmarking environment'
+
+      - script: |
+          source activate tomopy-bench
+          git clone --depth 1 https://github.com/tomopy/tomopy
+          cd tomopy
+          python setup.py install --enable-cuda --cuda-arch=30
+        displayName: Install TomoPy
+      
+      - script: |
+          source activate tomopy-bench
+          cd tomopy 
+          pip install pytest
+          pytest 
+        displayName: Test TomoPy
+
+      - bash: git clone --depth 1 https://github.com/tomopy/tomopy.github.io
+        displayName: Download benchmarking data repo
+
+      - script: |
+          source activate tomopy-bench
+          pip install click
+          TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
+          BRANCH_NAME=$TOMOPY_VERSION
+
+          cd tomopy.github.io
+          git checkout -B $BRANCH_NAME
+          cd ..
+
+          currentDate=`date +%F`
+          outputDir=tomopy.github.io/$currentDate/
+    
+          python -Om benchmarking.project \
+            --poisson 500 \
+            --trials 4 \
+            --width 400 \
+            --num-angles 50 \
+            --output-dir $outputDir 
+
+          cd tomopy.github.io
+          git config --global user.name "Dreycen Foiles"
+          git config --global user.email "foilesdreycen@gmail.com"
+          git add *
+          git commit -m "Bi-monthly benchmark"
+          git push https://$(PAT)@github.com/tomopy/tomopy.github.io 
+        displayName: Compute projections
+
+      - script: |  
+          conda env remove --yes -n tomopy
+          rm -rf tomopy.github.io
+          rm -rf tomopy
+        displayName: Remove existing build environment
 
   - job: CPU_Benchmarks
     timeoutInMinutes: 0
@@ -96,21 +166,16 @@ stages:
           --ncore 4 \
           --max-iter 50 \
           --output-dir $outputDir \
-          --algorithm $(algorithmName) \ 
-      displayName: 'Run benchmarks'
+          --algorithm $(algorithmName) 
 
-    - script: |
         cd tomopy.github.io
-        source activate tomopy-bench
-        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-        BRANCH_NAME=$TOMOPY_VERSION
-        git checkout -b $BRANCH_NAME
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
+        git pull -f 
         git add *
         git commit -m "Bi-monthly benchmark"
-        git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io
-      displayName: Add reconstruction algorithm to repository
+        git push https://$(PAT)@github.com/tomopy/tomopy.github.io
+      displayName: Compute reconstruction
 
     - script: |
         conda env remove --yes -n tomopy-bench
@@ -143,6 +208,7 @@ stages:
     - script: |
         conda env remove --yes -n tomopy-bench
         rm -rf tomopy.github.io
+        rm -rf tomopy
       displayName: Remove existing build environment  
       
     - script: conda env create --force -n tomopy-bench -f tomopy-bench.yaml 
@@ -177,21 +243,16 @@ stages:
           --ncore 4 \
           --max-iter 50 \
           --output-dir $outputDir \
-          --algorithm $(algorithmName) \ 
-      displayName: 'Run benchmarks'
+          --algorithm $(algorithmName)  
 
-    - script: |
         cd tomopy.github.io
-        source activate tomopy-bench
-        TOMOPY_VERSION=`python -c 'import tomopy; print(tomopy.__version__)'`
-        BRANCH_NAME=$TOMOPY_VERSION
-        git checkout -b $BRANCH_NAME
         git config --global user.name "Dreycen Foiles"
         git config --global user.email "foilesdreycen@gmail.com"
+        git pull -f 
         git add *
         git commit -m "Bi-monthly benchmark"
-        git push -uf https://$(PAT)@github.com/tomopy/tomopy.github.io
-      displayName: Add reconstruction algorithm to repository
+        git push https://$(PAT)@github.com/tomopy/tomopy.github.io
+      displayName: Compute reconstruction
 
     - script: |
         conda env remove --yes -n tomopy-bench
@@ -199,14 +260,18 @@ stages:
         rm -rf tomopy
       displayName: Remove existing build environment
   
-- stage: Summarize_results
+  - job: Summarize_results
+      
+    pool:
+      name: Default
+      demands: 
+        - Agent.OS -equals Linux
 
-  pool:
-    name: Default
-    demands: 
-      - Agent.OS -equals Linux
+    dependsOn:
+      - CPU_Benchmarks
+      - GPU_Benchmarks
 
-  steps:
+    steps:
 
   - download: current
     artifact: gridrec
@@ -234,3 +299,15 @@ stages:
         BRANCH_NAME="$TOMOPY_VERSION-"$(algorithmName)
         git checkout $BRANCH_NAME
         git config --global user.name "Dreycen Foiles"
+        git config --global user.email "foilesdreycen@gmail.com"
+        git add *
+        git commit -m "Bi-monthly benchmark"
+        git push https://$(PAT)@github.com/tomopy/tomopy.github.io 
+      displayName: Summarize data
+
+    - script: |
+        conda env remove --yes -n tomopy-bench
+        rm -rf tomopy.github.io
+        rm -rf tomopy
+      displayName: Remove existing build environment
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,6 +303,9 @@ jobs:
         git pull --no-rebase --allow-unrelated-histories -X theirs
         cd ..
 
+        currentDate=`date +%F`
+        outputDir=tomopy.github.io/$currentDate/
+
         python -Om benchmarking.summarize \
               --phantom peppers \
               --trials 4 \

--- a/benchmarking/reconstruct.py
+++ b/benchmarking/reconstruct.py
@@ -85,6 +85,14 @@ def main(phantom, max_iter, output_dir, ncore, parameters, algorithm):
                  'device': 'cpu', 'interpolation': 'LINEAR'},
                 {'algorithm': 'sirt', 'accelerated': True,
                  'device': 'cpu', 'interpolation': 'CUBIC'},
+            ],
+            'sirt_gpu': [
+                {'algorithm': 'sirt', 'accelerated':
+                 True, 'device': 'gpu', 'interpolation': 'NN'},
+                {'algorithm': 'sirt', 'accelerated':
+                    True, 'device': 'gpu', 'interpolation': 'LINEAR'},
+                {'algorithm': 'sirt', 'accelerated':
+                    True, 'device': 'gpu', 'interpolation': 'CUBIC'}
             ]
         }
 

--- a/tomopy-bench.yaml
+++ b/tomopy-bench.yaml
@@ -21,7 +21,6 @@ dependencies:
   - numpy ["blas=*=openblas"]
   - opencv>=3.4 ["blas=*=openblas"]
   - pyctest>0.0.10
-  - pytest
   - python=3.6
   - pywavelets
   - scikit-build

--- a/tomopy-bench.yaml
+++ b/tomopy-bench.yaml
@@ -21,6 +21,7 @@ dependencies:
   - numpy ["blas=*=openblas"]
   - opencv>=3.4 ["blas=*=openblas"]
   - pyctest>0.0.10
+  - pytest
   - python=3.6
   - pywavelets
   - scikit-build


### PR DESCRIPTION
Currently, the Azure pipeline will compute projections, reconstruction, and summarize benchmarking results all within the same job. This means that all the algorithms aren't being compared against each other. This pull request changes the pipeline so that all reconstruction results will be aggregated together before summarization. 