### PR TITLE
Tuning benchmark parameters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,9 @@ jobs:
 
           python -Om benchmarking.project \
             --poisson 500 \
-            --trials 4 \
-            --width 400 \
-            --num-angles 50 \
+            --trials 1 \
+            --width 360 \
+            --num-angles 512 \
             --output-dir $outputDir
 
           cd tomopy.github.io
@@ -166,8 +166,8 @@ jobs:
         outputDir=tomopy.github.io/$currentDate/
 
         python -Om benchmarking.reconstruct \
-          --ncore 4 \
-          --max-iter 50 \
+          --ncore 1 \
+          --max-iter 500 \
           --output-dir $outputDir \
           --algorithm $(algorithmName)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,8 +245,8 @@ jobs:
         outputDir=tomopy.github.io/$currentDate/
 
         python -Om benchmarking.reconstruct \
-          --ncore 4 \
-          --max-iter 50 \
+          --ncore 1 \
+          --max-iter 500 \
           --output-dir $outputDir \
           --algorithm $(algorithmName)
 

--- a/benchmarking/reconstruct.py
+++ b/benchmarking/reconstruct.py
@@ -63,6 +63,8 @@ def main(phantom, max_iter, output_dir, ncore, parameters, algorithm):
     Alternatively, a string representing a python list of dictionaries
     of parameters can be provided to run a custom subset of tests.
     """
+    logging.basicConfig(level=logging.INFO)
+    
     data = np.load(os.path.join(output_dir, phantom, 'simulated_data.npz'))
     dynamic_range = np.max(data['original'])
     if parameters is not None:

--- a/benchmarking/reconstruct.py
+++ b/benchmarking/reconstruct.py
@@ -91,10 +91,10 @@ def main(phantom, max_iter, output_dir, ncore, parameters, algorithm):
             'sirt_gpu': [
                 {'algorithm': 'sirt', 'accelerated':
                  True, 'device': 'gpu', 'interpolation': 'NN'},
-                {'algorithm': 'sirt', 'accelerated':
-                    True, 'device': 'gpu', 'interpolation': 'LINEAR'},
-                {'algorithm': 'sirt', 'accelerated':
-                    True, 'device': 'gpu', 'interpolation': 'CUBIC'}
+                # {'algorithm': 'sirt', 'accelerated':
+                #     True, 'device': 'gpu', 'interpolation': 'LINEAR'},
+                # {'algorithm': 'sirt', 'accelerated':
+                #     True, 'device': 'gpu', 'interpolation': 'CUBIC'}
             ]
         }
 

--- a/benchmarking/reconstruct.py
+++ b/benchmarking/reconstruct.py
@@ -64,7 +64,7 @@ def main(phantom, max_iter, output_dir, ncore, parameters, algorithm):
     of parameters can be provided to run a custom subset of tests.
     """
     logging.basicConfig(level=logging.INFO)
-    
+
     data = np.load(os.path.join(output_dir, phantom, 'simulated_data.npz'))
     dynamic_range = np.max(data['original'])
     if parameters is not None:
@@ -303,7 +303,8 @@ def reconstruct(
     if 'gridrec' in algorithm or 'fbp' in algorithm:
         iters, steps = [1], [1]
     else:
-        iters = np.unique(np.logspace(0, np.log10(max_iter), num=16, dtype=int))
+        iters = np.unique(np.logspace(
+            0, np.log10(max_iter), num=16, dtype=int))
         steps = [iters[0]] + np.diff(iters).tolist()
         np.testing.assert_array_equal(np.cumsum(steps), iters)
 
@@ -404,6 +405,7 @@ def reconstruct(
         if total_time > max_time * recon.shape[0]:
             logger.info(f"Terminate early due to {max_time}s time limit.")
             break
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
In its current state, the turbo-couscous benchmarks take far too long to run. This pull request changes the benchmark parameters so that they run in less than 2 horus, but still are sufficiently detailed that conclusions can be drawn from them.